### PR TITLE
cmake: Update minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.0)
+cmake_minimum_required (VERSION 3.16.3)
 project(optimization C CXX ASM)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)


### PR DESCRIPTION
We need at least 3.11 but the earliest version we've tested
with is actually 3.16.3, so requiring that.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>