### PR TITLE
Fix two build issues

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/chap8/ex9/pixel_shuffler.cpp
+++ b/chap8/ex9/pixel_shuffler.cpp
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include "pixel_shuffler.hpp"
 


### PR DESCRIPTION
```
$> gcc --version
gcc (Ubuntu 11.1.0-1ubuntu1~20.04) 11.1.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$> cmake --version
cmake version 3.16.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

Regarding the change from `master` -> `main`. Maybe `release-1.11.0` would be wiser.